### PR TITLE
Documenting udp option

### DIFF
--- a/README
+++ b/README
@@ -86,7 +86,11 @@ Recording a multicast address to a file:
 
 multicat @239.255.0.1:5004 /tmp/myfile.ts
 
-This will also create file /tmp/myfile.aux. Playing back the file:
+Recording a udp multicast address to a file:
+
+multicat -u @239.255.0.1:5004 /tmp/myfile.ts
+
+These recordings will also create a file /tmp/myfile.aux. Playing back the file:
 
 multicat -p 68 /tmp/myfile.ts 239.255.0.2:5004
 

--- a/multicat.1
+++ b/multicat.1
@@ -61,7 +61,7 @@ Overwrite or create RTP SSRC
 TTL of the packets send by multicat
 .TP
 .B \-u
-Source has no RTP header, possibly a udp source
+Source has no RTP header
 .TP
 .B \-U
 Destination has no RTP header

--- a/multicat.1
+++ b/multicat.1
@@ -61,7 +61,7 @@ Overwrite or create RTP SSRC
 TTL of the packets send by multicat
 .TP
 .B \-u
-Source has no RTP header
+Source has no RTP header, possibly a udp source
 .TP
 .B \-U
 Destination has no RTP header

--- a/multicat.c
+++ b/multicat.c
@@ -124,7 +124,7 @@ static void usage(void)
     msg_Raw( NULL, "    -r: in directory mode, rotate file after this duration (default: 97200000000 ticks = 1 hour)" );
     msg_Raw( NULL, "    -O: in directory mode, rotate file after duration + this offset (default: 0 tick = calendar hour)" );
     msg_Raw( NULL, "    -S: overwrite or create RTP SSRC" );
-    msg_Raw( NULL, "    -u: source has no RTP header" );
+    msg_Raw( NULL, "    -u: source has no RTP header, possibly a udp source" );
     msg_Raw( NULL, "    -U: destination has no RTP header" );
     msg_Raw( NULL, "    -m: size of the payload chunk, excluding optional RTP header (default 1316)" );
     msg_Raw( NULL, "    -R: size of the optional RTP header (default 12)" );


### PR DESCRIPTION
In using this tool I found that the `multicat -u` option was not as well documented to make it clear that this option not only works for rtp, but for udp as well. 