### PR TITLE
fix makefile for mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@
 VERSION = 2.3
 CFLAGS += -Wall -Wformat-security -O3 -fomit-frame-pointer -D_FILE_OFFSET_BITS=64 -D_ISOC99_SOURCE -D_BSD_SOURCE -D_DEFAULT_SOURCE
 CFLAGS += -g
-# Comment out the following line for Mac OS X build
-LDLIBS += -lrt -pthread
+
+ifneq ($(shell uname -s),Darwin)
+	LDLIBS += -lrt -pthread
+endif
 
 OBJ_MULTICAT = multicat.o util.o
 OBJ_INGESTS = ingests.o util.o


### PR DESCRIPTION
Problem:
- Despite suggesting Mac OS compatibility, it won't build via the INSTALL commands by default. There is a library dependency in the makefile which must be removed but no instructions to do-so other than in the Makefile itself. 

Solution:
- Make the Makefile work as-written for all OS's supported (including MacOS).