### PR TITLE
multilive: fix use of uninitialised memory

### DIFF
--- a/multilive.c
+++ b/multilive.c
@@ -1109,8 +1109,10 @@ int main( int i_argc, char **pp_argv )
         current = &fds[0];
 
         struct pollfd *pollfd = current++;
-        if (pollfd->revents & POLLIN)
+        if (pollfd->revents & POLLIN) {
             nl_read();
+            continue;
+        }
 
         peer_foreach_input(&config.peers, peer) {
             if (peer->fd < 0)


### PR DESCRIPTION
nl_read may start new peer that we need to add in the pollfd pool.