### PR TITLE
util.c: suppress GCC warnings when accessing 'struct udprawpkt' fields

### DIFF
--- a/util.c
+++ b/util.c
@@ -457,9 +457,19 @@ static void RawFillHeaders(struct udprawpkt *dgram,
 #if defined(__FreeBSD__)
     struct ip *iph = &(dgram->iph);
 #else
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
     struct iphdr *iph = &(dgram->iph);
+#pragma GCC diagnostic pop
 #endif
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
     struct udphdr *udph = &(dgram->udph);
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef DEBUG_SOCKET
     char ipsrc_str[16], ipdst_str[16];


### PR DESCRIPTION
util.c: In function ‘RawFillHeaders’:
util.c:461:25: warning: taking address of packed member of ‘struct udprawpkt’ may result in an unaligned pointer value [-Waddress-of-packed-member]
  461 |     struct iphdr *iph = &(dgram->iph);
      |                         ^~~~~~~~~~~~~
util.c:465:27: warning: taking address of packed member of ‘struct udprawpkt’ may result in an unaligned pointer value [-Waddress-of-packed-member]
  465 |     struct udphdr *udph = &(dgram->udph);
      |                           ^~~~~~~~~~~~~~